### PR TITLE
Makes the save cycle run asyncronously

### DIFF
--- a/core/src/main/java/fr/skytasul/quests/BeautyQuests.java
+++ b/core/src/main/java/fr/skytasul/quests/BeautyQuests.java
@@ -249,7 +249,7 @@ public class BeautyQuests extends JavaPlugin {
 					}
 				}
 			};
-			logger.info("Periodic saves task started (" + cycle + " ticks). Task ID: " + saveTask.runTaskTimer(this, cycle, cycle).getTaskId());
+			logger.info("Periodic saves task started (" + cycle + " ticks). Task ID: " + saveTask.runTaskTimerAsynchronously(this, cycle, cycle).getTaskId());
 		}
 	}
 	


### PR DESCRIPTION
Title ^ server spikes when plugin saves, making the save process async fixes this