### PR TITLE
Ability to set a quest launch limit via permission

### DIFF
--- a/core/src/main/java/fr/skytasul/quests/utils/Utils.java
+++ b/core/src/main/java/fr/skytasul/quests/utils/Utils.java
@@ -551,5 +551,12 @@ public class Utils{
 		if (type.name().equals("ILLUSIONER")) return XMaterial.BLAZE_POWDER;
 		return XMaterial.SPONGE;
 	}
-	
+
+	public static Optional<Integer> parseInt(String toParse) {
+		try {
+			return Optional.of(Integer.parseInt(toParse));
+		} catch (NumberFormatException e) {
+			return Optional.empty();
+		}
+	}
 }


### PR DESCRIPTION
Salut,

Avant on regardait le nombre maximum autorisé pour lancer une quête dans la config. Dans ma PR je ne me base qu'en dernier recours sur cette valeur. 
On récupère la liste des permissions que possède le joueur, je filtre par la permission de `beautyquest.start.`, je récupère toutes les valeurs int valides à la fin de cette permission et je fais un max pour récupérer la valeur la plus haute.
Si le joueur n'a pas la permission ou que la valeur est 0, on ne check pas la limite sinon, s'il faut afficher le message, on affiche le message de limite. Enfin, on vérifie comme avant si une valeur max est définie dans la config et on affiche si nécessaire.

Si jamais cette nouvelle version peut te filer un coup de pouce, ça m'va !
Merci pour le boulot sur le plugin, il nous dépatouille bien sur notre event comme chaque année ;)