### PR TITLE
Add an MMOItems item comparison

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -148,6 +148,10 @@
 			<id>bg-repo</id>
 			<url>https://repo.bg-software.com/repository/api/</url>
 		</repository>
+		<repository>
+			<id>phoenix</id>
+			<url>https://nexus.phoenixdevt.fr/repository/maven-public/</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
@@ -309,6 +313,18 @@
 			<groupId>com.zaxxer</groupId>
 			<artifactId>HikariCP</artifactId>
 			<version>4.0.3</version> <!-- For Java 8 compatibility -->
+		</dependency>
+		<dependency>
+			<groupId>io.lumine</groupId>
+			<artifactId>MythicLib-dist</artifactId>
+			<version>1.5.1-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.Indyuce</groupId>
+			<artifactId>MMOItems-API</artifactId>
+			<version>6.9.1-SNAPSHOT</version>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Local JARs -->

--- a/core/src/main/java/fr/skytasul/quests/api/QuestsAPI.java
+++ b/core/src/main/java/fr/skytasul/quests/api/QuestsAPI.java
@@ -86,9 +86,15 @@ public final class QuestsAPI {
 	}
 	
 	public static void registerItemComparison(ItemComparison comparison) {
-		Validate.isTrue(itemComparisons.stream().noneMatch(x -> x.getID().equals(comparison.getID())), "This item comparison was already registerd");
+		Validate.isTrue(itemComparisons.stream().noneMatch(x -> x.getID().equals(comparison.getID())), "This item comparison was already registered");
 		itemComparisons.add(comparison);
 		DebugUtils.logMessage("Item comparison registered (id: " + comparison.getID() + ")");
+	}
+
+	public static void unregisterItemComparison(ItemComparison comparison) {
+		boolean registered = itemComparisons.remove(comparison);
+		Validate.isTrue(registered, "This item comparison was not registered");
+		DebugUtils.logMessage("Item comparison unregistered (id: " + comparison.getID() + ")");
 	}
 	
 	public static List<MobStacker> getMobStackers() {

--- a/core/src/main/java/fr/skytasul/quests/utils/Lang.java
+++ b/core/src/main/java/fr/skytasul/quests/utils/Lang.java
@@ -662,6 +662,8 @@ public enum Lang implements Locale {
 	comparisonEnchantsLore("inv.itemComparisons.enchantsLore"),
 	comparisonRepairCost("inv.itemComparisons.repairCost"),
 	comparisonRepairCostLore("inv.itemComparisons.repairCostLore"),
+	comparisonMmoItems("inv.itemComparisons.mmoItems"),
+	comparisonMmoItemsLore("inv.itemComparisons.mmoItemsLore"),
 	
 	INVENTORY_EDIT_TITLE("inv.editTitle.name"),
 	title_title("inv.editTitle.title"),

--- a/core/src/main/java/fr/skytasul/quests/utils/compatibility/BQMMOItems.java
+++ b/core/src/main/java/fr/skytasul/quests/utils/compatibility/BQMMOItems.java
@@ -1,0 +1,41 @@
+package fr.skytasul.quests.utils.compatibility;
+
+import fr.skytasul.quests.api.QuestsAPI;
+import fr.skytasul.quests.api.comparison.ItemComparison;
+import fr.skytasul.quests.utils.Lang;
+import net.Indyuce.mmoitems.MMOItems;
+import net.Indyuce.mmoitems.api.Type;
+import org.bukkit.inventory.ItemStack;
+
+public class BQMMOItems {
+
+    private static final ItemComparison COMPARISON = new ItemComparison(
+            "mmoItems",
+            Lang.comparisonMmoItems.toString(),
+            Lang.comparisonMmoItemsLore.toString(),
+            BQMMOItems::compareMmoItems
+    );
+
+    private BQMMOItems() {}
+
+    public static void initialize() {
+        QuestsAPI.registerItemComparison(COMPARISON);
+    }
+
+    public static void disable() {
+        QuestsAPI.unregisterItemComparison(COMPARISON);
+    }
+
+    private static boolean compareMmoItems(ItemStack item1, ItemStack item2) {
+        Type type1 = MMOItems.getType(item1);
+        Type type2 = MMOItems.getType(item2);
+        if (type1 == null || !type1.equals(type2)) {
+            return false;
+        }
+
+        String id1 = MMOItems.getID(item1);
+        String id2 = MMOItems.getID(item2);
+        return id1 != null && id1.equals(id2);
+    }
+
+}

--- a/core/src/main/java/fr/skytasul/quests/utils/compatibility/DependenciesManager.java
+++ b/core/src/main/java/fr/skytasul/quests/utils/compatibility/DependenciesManager.java
@@ -126,6 +126,8 @@ public class DependenciesManager implements Listener {
 	public static final BQDependency ultimateTimber = new BQDependency("UltimateTimber", () -> Bukkit.getPluginManager().registerEvents(new BQUltimateTimber(), BeautyQuests.getInstance()));
 	public static final BQDependency PlayerBlockTracker = new BQDependency("PlayerBlockTracker");
 	public static final BQDependency WildStacker = new BQDependency("WildStacker", BQWildStacker::initialize);
+	public static final BQDependency mmoItems =
+			new BQDependency("MMOItems", BQMMOItems::initialize, BQMMOItems::disable, null);
 	
 	//public static final BQDependency par = new BQDependency("Parties");
 	//public static final BQDependency eboss = new BQDependency("EpicBosses", () -> Bukkit.getPluginManager().registerEvents(new EpicBosses(), BeautyQuests.getInstance()));
@@ -140,7 +142,7 @@ public class DependenciesManager implements Listener {
 		dependencies = new ArrayList<>(Arrays.asList(
 				/*par, eboss, */
 				znpcs, citizens, // npcs
-				wg, gps, tokenEnchant, ultimateTimber, sentinel, PlayerBlockTracker, // other
+				wg, gps, tokenEnchant, ultimateTimber, sentinel, PlayerBlockTracker, mmoItems, // other
 				mm, boss, advancedspawners, LevelledMobs, WildStacker, // mobs
 				vault, papi, acc, // hooks
 				skapi, jobs, fac, mmo, mclvl, // rewards and requirements

--- a/core/src/main/resources/locales/en_US.yml
+++ b/core/src/main/resources/locales/en_US.yml
@@ -701,6 +701,8 @@ inv:
     enchantsLore: Compares items enchants
     repairCost: Repair cost
     repairCostLore: Compares repair cost for armors and swords
+    mmoItems: MMOItems item
+    mmoItemsLore: Compares MMOItems types and IDs
   editTitle:
     name: Edit Title
     title: §6Title

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -36,6 +36,7 @@ softdepend:
 - PlayerBlockTracker
 - LevelledMobs
 - WildStacker
+- MMOItems
 
 #commands:
 #  beautyquests:


### PR DESCRIPTION
This was requested by someone in [this](https://discord.com/channels/482632781395132416/1060285856591654932) Discord post:

> Hello. Please add support for MMOItems in bring back quests. Its not hard to add, its only one api method needed to check for a valid item. Its very hard to do currently and thousands of servers use mmoitems as a main plugin for items. Thank you :zuwu: 🙂 

This PR solves this by adding an extra `ItemComparison` that's registered conditionally if MMOItems is loaded and simply checks whether the MMOItems type and ID of an item are the same.

This is a more natural way of comparing two MMOItems than checking the full NBT data, since the NBT data could change -- for example -- when the MMOItems plugin is updated or the lore of an MMOItems item is changed. With this extra item comparison, server administrators won't have to worry about updating their quests when an insignificant part of an MMOItems item changes.